### PR TITLE
v0.3.3 fixing major edge cases for triangulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - `PointInTriangle` method in `VGMath` is much more accurate (to handle edge cases) and computationally cheap.
+- Removed addition of `EPSILON` to `div` in `Cirumcircle` to prevent numerical inaccuracy.
 
 ## [0.3.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.4.0]
+
+### Changes
+
+- Renamed `GenerateMeshDataFromGlyph` to `ExtractGlyphData`.
+
 ## [0.3.2]
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Renamed `GenerateMeshDataFromGlyph` to `ExtractGlyphData`.
 
+### Bug Fixes
+
+- `PointInTriangle` method in `VGMath` is much more accurate (to handle edge cases) and computationally cheap.
+
 ## [0.3.2]
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,65 @@
-## [0.4.0]
+## [0.3.3]
+
+### New Features
+
+- `FontCurve` stores an array of precomputed meshes on import.
+- Implementation of binary search to search for character's glyph/mesh index.
 
 ### Changes
 
+- Burst Compile uses high precision float and strict float mode.
+- Reduced `MARGIN` from 10.0f to 1.0f.
+- Renamed `Circumcenter` to `Circumcircle`.
 - Renamed `GenerateMeshDataFromGlyph` to `ExtractGlyphData`.
+- Increased `FontImporter` verion from 2 to 3.
+- Instead of `charMaps`, `FontCurve` now stores 2 separate arrays:
+  - `charCodes`: an array of supported characters.
+  - `glyphIndices`: an array of glyph indices corresponding to the supported character codes.
+- Uses "super-triangle" instead of "rect-triangles" as there is an elegant way to create a huge triangle that encapsulates all points inside.
+  1. Calculate bounding-box (min/max rect) of the points.
+  2. Place the bounding-box on a line.
+   ```
+    __
+   |__|
+   ----
+   ```
+  3. Place 2 more of the same box at the top and bottom of the current box.
+   ```
+    __
+   |__|
+    __
+   |__|
+    __
+   |__|
+   ----
+   ```
+  4. Place another 2 more of the same box at the left and right of the bottom most box.
+   ```
+         __
+        |__|
+         __
+        |__|
+    __   __   __
+   |__| |__| |__|
+   --------------
+   ```
+  5. Now, connect the "left-bottom most" point, "right-bottom most" point, and the "middle-top-most" point together.
+   ```
+         __                 /\      
+        |__|               /__\     
+         __               / __ \    
+        |__|             / |__| \   
+    __   __   __       _/   __   \_ 
+   |__| |__| |__|     |/_| |__| |_\|
+   ----------------------------------
+   ```
+  6. And now you get a "super-triangle" that encapsulates all the points in the middle box! (of course, you can add some kind of margin to the box itself to enlarge the "super-triangle" just to make sure!)
 
 ### Bug Fixes
 
 - `PointInTriangle` method in `VGMath` is much more accurate (to handle edge cases) and computationally cheap.
 - Removed addition of `EPSILON` to `div` in `Cirumcircle` to prevent numerical inaccuracy.
+- `TriEdgeIntersect` method now checks for similarity based on point position rather than index as there might be duplicated points that have a different index.
 
 ## [0.3.2]
 
@@ -33,7 +85,7 @@
 
 ### Changes
 
-- Uses "rect-triangles" instead of "supra-triangles" for stability. This can prevent some points from being excluded when the min and max rect is large.
+- Uses "rect-triangles" instead of "super-triangles" for stability. This can prevent some points from being excluded when the min and max rect is large.
 
 ## [0.3.0]
 

--- a/Editor/FontImporter.cs
+++ b/Editor/FontImporter.cs
@@ -251,89 +251,87 @@ namespace Voxell.GPUVectorGraphics.Font
       Dictionary<uint, uint> characterRemap = null;
       foreach (CMap.CharacterConversionMap ccm in cMap.EnumCharacterMaps())
       {
-        characterRemap = ccm.MapCodeToIndex(fontReader);
-        break;
+        Dictionary<uint, uint> potentialMap = ccm.MapCodeToIndex(fontReader);
+        if (characterRemap == null || potentialMap.Count > characterRemap.Count)
+          characterRemap = potentialMap;
       }
 
-      int keyCount =  characterRemap.Keys.Count;
-      int[] charMap = new int[keyCount];
+      List<int> charCodesList = new List<int>();
+      charCodesList.Add(0);
+      List<int> glyphIndicesList = new List<int>();
+      glyphIndicesList.Add(0);
+
       foreach (KeyValuePair<uint, uint> kvp in characterRemap)
       {
-        int code = (int)kvp.Key;
-        int idx = (int)kvp.Value;
-        charMap[code] = idx;
+        int key = (int) kvp.Key;
+        int value = (int) kvp.Value;
+
+        if (value == 0 || value >= glyphCount) continue;
+        charCodesList.Add(key);
+        glyphIndicesList.Add(value);
       }
+
+      int[] charCodes = charCodesList.ToArray();
+      int[] glyphIndices = glyphIndicesList.ToArray();
+
+      System.Array.Sort(charCodes, glyphIndices);
+      // sort character codes
       #endregion
 
       _tableMap.Clear();
       fontReader.Close();
 
       FontCurve fontCurve = ScriptableObject.CreateInstance<FontCurve>();
-      fontCurve.Initialize(glyphs, charMap);
+      fontCurve.Initialize(glyphs, charCodes, glyphIndices);
       ctx.AddObjectToAsset("FontCurve", fontCurve);
 
       /// create mesh for each char
       ////////////////////////////////////////////////////////////////////////////////
-      HashSet<int> glyphSet = new HashSet<int>();
-      Dictionary<int, int> glyphMap = new Dictionary<int, int>();
-      for (int c=0; c < charMap.Length; c++)
-      {
-        glyphSet.Add(charMap[c]);
-        glyphMap.TryAdd(charMap[c], c);
-      }
-
-      int glyphSetCount = glyphSet.Count;
-      // convert set into array
-      int[] glyphSetArray = new int[glyphSetCount];
-      glyphSet.CopyTo(glyphSetArray);
-
-      Mesh[] meshes = new Mesh[glyphSetCount];
-      NativeArray<JobHandle> jobHandles = new NativeArray<JobHandle>(glyphSetCount, Allocator.Temp);
+      int keyCount = charCodes.Length;
+      Mesh[] meshes = new Mesh[keyCount];
+      NativeArray<JobHandle> jobHandles = new NativeArray<JobHandle>(keyCount, Allocator.Temp);
 
       NativeArray<float2>[] na_points_array =
-        new NativeArray<float2>[glyphSetCount];
+        new NativeArray<float2>[keyCount];
       NativeList<int>[] na_triangles_array =
-        new NativeList<int>[glyphSetCount];
+        new NativeList<int>[keyCount];
       NativeArray<CDT.ContourPoint>[] na_contours_array =
-        new NativeArray<CDT.ContourPoint>[glyphSetCount];
+        new NativeArray<CDT.ContourPoint>[keyCount];
 
-      for (int g=0; g < glyphSetCount; g++)
+      for (int k=0; k < keyCount; k++)
       {
-        int gIdx = glyphSetArray[g];
-
-        Glyph glyph = glyphs[gIdx];
+        Glyph glyph = glyphs[glyphIndices[k]];
         if (glyph.contours == null) continue;
         int contourCount = glyph.contours.Length;
         if (contourCount == 0) continue;
 
         float2[] points;
         CDT.ContourPoint[] contours;
-        ExtractGlyphData(in glyph, out points, out contours);
+        FontCurve.ExtractGlyphData(in glyph, out points, out contours);
 
         float2 maxRect = glyph.maxRect;
         float2 minRect = glyph.minRect;
-        jobHandles[g] = CDT.ConstraintTriangulate(
+        jobHandles[k] = CDT.ConstraintTriangulate(
           minRect, maxRect, in points, in contours,
-          out na_points_array[g],
-          out na_triangles_array[g],
-          out na_contours_array[g]
+          out na_points_array[k],
+          out na_triangles_array[k],
+          out na_contours_array[k]
         );
       }
 
       // make sure that all the scheduled jobs are completed
       JobHandle.CompleteAll(jobHandles);
 
-      for (int g=0; g < glyphSetCount; g++)
+      for (int k=0; k < keyCount; k++)
       {
-        int gIdx = glyphSetArray[g];
-        if (!na_points_array[g].IsCreated) continue;
-        Glyph glyph = glyphs[gIdx];
+        if (!na_points_array[k].IsCreated) continue;
+        Glyph glyph = glyphs[glyphIndices[k]];
 
-        string name = ((char)glyphMap[gIdx]).ToString();
+        string name = ((char)charCodes[k]).ToString();
         Mesh mesh = new Mesh();
         mesh.name = name;
-        mesh.SetVertices(PointsToVertices(in na_points_array[g]));
-        mesh.SetIndices<int>(na_triangles_array[g], MeshTopology.Triangles, 0);
+        mesh.SetVertices(FontCurve.PointsToVertices(in na_points_array[k]));
+        mesh.SetIndices<int>(na_triangles_array[k], MeshTopology.Triangles, 0);
         mesh.RecalculateNormals();
         mesh.RecalculateTangents();
 
@@ -348,52 +346,15 @@ namespace Voxell.GPUVectorGraphics.Font
 
       // dispose all allocated arrays
       jobHandles.Dispose();
-      for (int g=0; g < glyphSetCount; g++)
+      for (int k=0; k < keyCount; k++)
       {
-        if(na_points_array[g].IsCreated)
-          na_points_array[g].Dispose();
-        if(na_triangles_array[g].IsCreated)
-          na_triangles_array[g].Dispose();
-        if(na_contours_array[g].IsCreated)
-          na_contours_array[g].Dispose();
+        if(na_points_array[k].IsCreated)
+          na_points_array[k].Dispose();
+        if(na_triangles_array[k].IsCreated)
+          na_triangles_array[k].Dispose();
+        if(na_contours_array[k].IsCreated)
+          na_contours_array[k].Dispose();
       }
-    }
-
-    /// <summary>Convert glyphs into points and contours.</summary>
-    private void ExtractGlyphData(
-      in Glyph glyph, out float2[] points, out CDT.ContourPoint[] contours
-    )
-    {
-      int contourCount = glyph.contours.Length;
-      List<float2> pointList = new List<float2>();
-      List<CDT.ContourPoint> contourList = new List<CDT.ContourPoint>();
-
-      int contourStart = 0;
-      for (int c=0; c < contourCount; c++)
-      {
-        QuadraticContour glyphContour = glyph.contours[c];
-        int segmentCount = glyphContour.segments.Length;
-
-        for (int s=0; s < segmentCount; s++)
-        {
-          pointList.Add(glyphContour.segments[s].p0);
-          contourList.Add(new CDT.ContourPoint(contourStart+s, c));
-        }
-        contourList.Add(new CDT.ContourPoint(contourStart, c));
-        contourStart += segmentCount;
-      }
-
-      points = pointList.ToArray();
-      contours = contourList.ToArray();
-    }
-
-    private Vector3[] PointsToVertices(in NativeArray<float2> points)
-    {
-      Vector3[] vertices = new Vector3[points.Length];
-      for (int p=0; p < points.Length; p++)
-        vertices[p] = new Vector3(points[p].x, points[p].y, 0.0f);
-
-      return vertices;
     }
   }
 }

--- a/Editor/FontImporter.cs
+++ b/Editor/FontImporter.cs
@@ -308,7 +308,7 @@ namespace Voxell.GPUVectorGraphics.Font
 
         float2[] points;
         CDT.ContourPoint[] contours;
-        GenerateMeshDataFromGlyph(in glyph, out points, out contours);
+        ExtractGlyphData(in glyph, out points, out contours);
 
         float2 maxRect = glyph.maxRect;
         float2 minRect = glyph.minRect;
@@ -359,7 +359,8 @@ namespace Voxell.GPUVectorGraphics.Font
       }
     }
 
-    private void GenerateMeshDataFromGlyph(
+    /// <summary>Convert glyphs into points and contours.</summary>
+    private void ExtractGlyphData(
       in Glyph glyph, out float2[] points, out CDT.ContourPoint[] contours
     )
     {

--- a/Editor/FontImporter.cs
+++ b/Editor/FontImporter.cs
@@ -10,7 +10,7 @@ namespace Voxell.GPUVectorGraphics.Font
 {
   using Inspector;
 
-  [ScriptedImporter(2,  new[] { "ttfvector", "otfVector" }, new[] { "ttf", "otf" })]
+  [ScriptedImporter(3,  new[] { "ttfvector", "otfVector" }, new[] { "ttf", "otf" })]
   public class FontImporter : ScriptedImporter
   {
     /// <summary>Format of the font.</summary>
@@ -282,7 +282,6 @@ namespace Voxell.GPUVectorGraphics.Font
       fontReader.Close();
 
       FontCurve fontCurve = ScriptableObject.CreateInstance<FontCurve>();
-      fontCurve.Initialize(glyphs, charCodes, glyphIndices);
       ctx.AddObjectToAsset("FontCurve", fontCurve);
 
       /// create mesh for each char
@@ -309,8 +308,8 @@ namespace Voxell.GPUVectorGraphics.Font
         CDT.ContourPoint[] contours;
         FontCurve.ExtractGlyphData(in glyph, out points, out contours);
 
-        float2 maxRect = glyph.maxRect * FontCurve.ENLARGE;
-        float2 minRect = glyph.minRect * FontCurve.ENLARGE;
+        float2 maxRect = glyph.maxRect;
+        float2 minRect = glyph.minRect;
         jobHandles[k] = CDT.ConstraintTriangulate(
           minRect, maxRect, in points, in contours,
           out na_points_array[k],
@@ -345,8 +344,11 @@ namespace Voxell.GPUVectorGraphics.Font
         float3 center = minRect + size*0.5f;
         mesh.bounds = new Bounds(center, size);
 
+        meshes[k] = mesh;
         ctx.AddObjectToAsset(name, mesh);
       }
+
+      fontCurve.Initialize(glyphs, charCodes, glyphIndices, meshes);
 
       // dispose all allocated arrays
       jobHandles.Dispose();

--- a/Editor/FontImporter.cs
+++ b/Editor/FontImporter.cs
@@ -309,18 +309,22 @@ namespace Voxell.GPUVectorGraphics.Font
         CDT.ContourPoint[] contours;
         FontCurve.ExtractGlyphData(in glyph, out points, out contours);
 
-        float2 maxRect = glyph.maxRect;
-        float2 minRect = glyph.minRect;
+        float2 maxRect = glyph.maxRect * FontCurve.ENLARGE;
+        float2 minRect = glyph.minRect * FontCurve.ENLARGE;
         jobHandles[k] = CDT.ConstraintTriangulate(
           minRect, maxRect, in points, in contours,
           out na_points_array[k],
           out na_triangles_array[k],
           out na_contours_array[k]
         );
+
+        Debug.Log(glyphIndices[k]);
+        Debug.Log((char)charCodes[k]);
+        jobHandles[k].Complete();
       }
 
       // make sure that all the scheduled jobs are completed
-      JobHandle.CompleteAll(jobHandles);
+      // JobHandle.CompleteAll(jobHandles);
 
       for (int k=0; k < keyCount; k++)
       {

--- a/Runtime/CDT/CDT.ConstraintUtil.cs
+++ b/Runtime/CDT/CDT.ConstraintUtil.cs
@@ -86,7 +86,6 @@ namespace Voxell.GPUVectorGraphics
     /// <param name="ePoints">2 points that makes up the edge</param>
     /// <param name="diff_t">if triangle point is part of the edge</param>
     /// <param name="tPoints">triangle points</param>
-    /// <returns></returns>
     private static bool TriEdgeIntersect(
       in NativeArray<float2> na_points,
       in int3 tIdx, in Edge edge, in float2x2 ePoints,
@@ -97,8 +96,11 @@ namespace Voxell.GPUVectorGraphics
       tPoints = new float2x3();
       for (int i=0; i < 3; i++)
       {
-        diff_t[i] = !(tIdx[i] == edge.e0 || tIdx[i] == edge.e1);
         tPoints[i] = na_points[tIdx[i]];
+        // compare point position rather than index
+        // as there might be duplicated points with different index
+        bool same = (tPoints[i].Equals(ePoints[0]) || tPoints[i].Equals(ePoints[1]));
+        diff_t[i] = !same;
       }
 
       // only check for edge intersection when both edge are not connected

--- a/Runtime/CDT/CDT.ConstraintUtil.cs
+++ b/Runtime/CDT/CDT.ConstraintUtil.cs
@@ -29,7 +29,11 @@ namespace Voxell.GPUVectorGraphics
 
         if (edge.Equals(edge0) || edge.Equals(edge1) || edge.Equals(edge2))
         {
-          // UnityEngine.Debug.Log($"{foundCount}: {t0}, {t1}, {t2}");
+          if (foundCount == 2)
+          {
+            UnityEngine.Debug.Log($"{foundCount}: {t0}, {t1}, {t2}");
+            UnityEngine.Debug.Log($"edge: {edge.e0}:{edge.e1}");
+          }
           tris[foundCount] = t;
 
           // find the odd one out (the point that is not related to the given edge)
@@ -65,7 +69,11 @@ namespace Voxell.GPUVectorGraphics
 
         if (edge.Equals(edge0) || edge.Equals(edge1) || edge.Equals(edge2))
         {
-          // UnityEngine.Debug.Log($"{foundCount}: {t0}, {t1}, {t2}");
+          if (foundCount == 2)
+          {
+            UnityEngine.Debug.Log($"{foundCount}: {t0}, {t1}, {t2}");
+            UnityEngine.Debug.Log($"edge: {edge.e0}:{edge.e1}");
+          }
           tris[foundCount++] = t;
         }
       }

--- a/Runtime/CDT/CDT.ConstraintUtil.cs
+++ b/Runtime/CDT/CDT.ConstraintUtil.cs
@@ -10,7 +10,7 @@ namespace Voxell.GPUVectorGraphics
     /// at a hash map from any of the point related to the edge.
     /// </summary>
     private static void FindEdgeTriangleAndExtraPoint(
-      in NativeMultiHashMap<int, int>.Enumerator enumarator,
+      in NativeMultiHashMap<int, int>.Enumerator enumerator,
       in NativeList<int> na_triangles,
       in Edge edge, out int2 tris, out int2 extraPoints)
     {
@@ -18,8 +18,9 @@ namespace Voxell.GPUVectorGraphics
       tris = new int2(-1, -1);
       extraPoints = new int2(-1, -1);
 
+      // UnityEngine.Debug.Log($"edge: {edge.e0}:{edge.e1}");
       int t0, t1, t2;
-      foreach (int t in enumarator)
+      foreach (int t in enumerator)
       {
         GetTriangleIndices(in na_triangles, t, out t0, out t1, out t2);
         Edge edge0 = new Edge(t0, t1);
@@ -28,6 +29,7 @@ namespace Voxell.GPUVectorGraphics
 
         if (edge.Equals(edge0) || edge.Equals(edge1) || edge.Equals(edge2))
         {
+          // UnityEngine.Debug.Log($"{foundCount}: {t0}, {t1}, {t2}");
           tris[foundCount] = t;
 
           // find the odd one out (the point that is not related to the given edge)
@@ -45,15 +47,16 @@ namespace Voxell.GPUVectorGraphics
     /// at a hash map from any of the point related to the edge.
     /// </summary>
     private static void FindEdgeTriangles(
-      in NativeMultiHashMap<int, int>.Enumerator enumarator,
+      in NativeMultiHashMap<int, int>.Enumerator enumerator,
       in NativeList<int> na_triangles,
       in Edge edge, out int2 tris)
     {
       int foundCount = 0;
       tris = new int2(-1, -1);
 
+      // UnityEngine.Debug.Log($"edge: {edge.e0}:{edge.e1}");
       int t0, t1, t2;
-      foreach (int t in enumarator)
+      foreach (int t in enumerator)
       {
         GetTriangleIndices(in na_triangles, t, out t0, out t1, out t2);
         Edge edge0 = new Edge(t0, t1);
@@ -61,7 +64,10 @@ namespace Voxell.GPUVectorGraphics
         Edge edge2 = new Edge(t2, t0);
 
         if (edge.Equals(edge0) || edge.Equals(edge1) || edge.Equals(edge2))
+        {
+          // UnityEngine.Debug.Log($"{foundCount}: {t0}, {t1}, {t2}");
           tris[foundCount++] = t;
+        }
       }
     }
 

--- a/Runtime/CDT/CDT.Primitive.cs
+++ b/Runtime/CDT/CDT.Primitive.cs
@@ -48,7 +48,7 @@ namespace Voxell.GPUVectorGraphics
       public bool ContainsPoint(float2 p)
       {
         float sqlength = math.lengthsq(center - p);
-        return sqlength < (sqradius + math.EPSILON);
+        return sqlength < (sqradius + math.EPSILON*2.0f);
       }
     }
 

--- a/Runtime/CDT/CDT.Primitive.cs
+++ b/Runtime/CDT/CDT.Primitive.cs
@@ -49,7 +49,7 @@ namespace Voxell.GPUVectorGraphics
       public bool ContainsPoint(float2 p)
       {
         float sqlength = math.lengthsq(center - p);
-        return sqlength <= sqradius;
+        return sqlength < sqradius;
       }
     }
 

--- a/Runtime/CDT/CDT.Primitive.cs
+++ b/Runtime/CDT/CDT.Primitive.cs
@@ -49,7 +49,7 @@ namespace Voxell.GPUVectorGraphics
       public bool ContainsPoint(float2 p)
       {
         float sqlength = math.lengthsq(center - p);
-        return sqlength < sqradius;
+        return sqlength < (sqradius + math.EPSILON);
       }
     }
 

--- a/Runtime/CDT/CDT.Primitive.cs
+++ b/Runtime/CDT/CDT.Primitive.cs
@@ -25,12 +25,12 @@ namespace Voxell.GPUVectorGraphics
         (this.e0 == other.e1 && this.e1 == other.e0);
     }
 
-    private struct Circumcenter
+    private struct Cirumcircle
     {
       public float2 center;
       public float sqradius;
 
-      public Circumcenter(float2 p0, float2 p1, float2 p2)
+      public Cirumcircle(float2 p0, float2 p1, float2 p2)
       {
         float dA = p0.x * p0.x + p0.y * p0.y;
         float dB = p1.x * p1.x + p1.y * p1.y;
@@ -39,7 +39,6 @@ namespace Voxell.GPUVectorGraphics
         float aux1 = dA * (p2.y - p1.y) + dB * (p0.y - p2.y) + dC * (p1.y - p0.y);
         float aux2 = -(dA * (p2.x - p1.x) + dB * (p0.x - p2.x) + dC * (p1.x - p0.x));
         float div = 2.0f * (p0.x * (p2.y - p1.y) + p1.x * (p0.y - p2.y) + p2.x * (p1.y - p0.y));
-        div += math.EPSILON;
         div = 1.0f / div;
 
         center = new float2(aux1, aux2) * div;

--- a/Runtime/CDT/CDT.Primitive.cs
+++ b/Runtime/CDT/CDT.Primitive.cs
@@ -49,7 +49,7 @@ namespace Voxell.GPUVectorGraphics
       public bool ContainsPoint(float2 p)
       {
         float sqlength = math.lengthsq(center - p);
-        return sqlength < sqradius;
+        return sqlength <= sqradius;
       }
     }
 

--- a/Runtime/CDT/CDT.QuadraticInsert.cs
+++ b/Runtime/CDT/CDT.QuadraticInsert.cs
@@ -1,0 +1,76 @@
+using Unity.Mathematics;
+using Unity.Collections;
+using Unity.Jobs;
+using Unity.Burst;
+
+namespace Voxell.GPUVectorGraphics
+{
+  using Mathx;
+
+  public partial class CDT
+  {
+    // inserting quadratic control points from the contour
+    [BurstCompile]
+    private struct QuadraticInsertJob : IJob
+    {
+      public NativeArray<float2> na_points;
+      public NativeArray<float2> na_controlPoints;
+      public NativeList<int> na_triangles;
+
+      public void Execute()
+      {
+        NativeMultiHashMap<int, int> na_pointTriMap = new NativeMultiHashMap<int, int>(
+          na_points.Length, Allocator.Temp
+        );
+
+        // create point idx to related triangles map
+        for (int t=0, triangleCount=na_triangles.Length/3; t < triangleCount; t++)
+        {
+          int t0, t1, t2;
+          GetTriangleIndices(in na_triangles, t, out t0, out t1, out t2);
+
+          na_pointTriMap.Add(t0, t);
+          na_pointTriMap.Add(t1, t);
+          na_pointTriMap.Add(t2, t);
+        }
+
+        for (int p=0, pointCount=na_controlPoints.Length; p < pointCount; p++)
+        {
+          float2 controlPoint = na_controlPoints[p];
+          // ignore if control point location is exactly same as the triangulation point
+          if (na_points[p].Equals(controlPoint)) continue;
+
+          // contour edge
+          int nextP = (p + 1) % pointCount;
+          Edge edge = new Edge(p, nextP);
+          float2 p0 = na_points[edge.e0];
+          float2 p1 = na_points[edge.e1];
+          float2 n = math.normalize(float2x.perpendicular(p1 - p0));
+
+          // if point is outside the contour, directly triangulate it as it will not overlap any triangles
+          if (math.dot(controlPoint - p0, n) > 0.0f)
+          {
+            // 
+          } else
+          // if point is inside the contour, check for triangle intersections
+          // remove them and then retriangulate them
+          {
+            NativeMultiHashMap<int, int>.Enumerator enumerator0 = na_pointTriMap.GetValuesForKey(edge.e0);
+            NativeMultiHashMap<int, int>.Enumerator enumerator1 = na_pointTriMap.GetValuesForKey(edge.e1);
+
+            // line 0: p0, controlPoint
+            // line 1: p1, controlPoint
+
+            NativeList<int> na_intersectedTriangles = new NativeList<int>(Allocator.Temp);
+
+            foreach (int t in enumerator0)
+            {
+              int t0, t1, t2;
+              GetTriangleIndices(in na_triangles, t, out t0, out t1, out t2);
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Runtime/CDT/CDT.QuadraticInsert.cs.meta
+++ b/Runtime/CDT/CDT.QuadraticInsert.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a8c90f035c57fd4688a89fd0365efd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/CDT/CDT.Triangulate.cs
+++ b/Runtime/CDT/CDT.Triangulate.cs
@@ -47,6 +47,10 @@ namespace Voxell.GPUVectorGraphics
 
           float2 point = na_points[p];
 
+          // prevent duplicated points (only triangulate the first point found)
+          int tempIdx = na_points.IndexOf(point);
+          if (tempIdx != p) continue;
+
           // remove triangles that contains the current point in its circumcenter
           int removeCount = 0;
           for (int c=0, circumCount=na_circumcenters.Length; c < circumCount; c++)

--- a/Runtime/CDT/CDT.Triangulate.cs
+++ b/Runtime/CDT/CDT.Triangulate.cs
@@ -57,7 +57,6 @@ namespace Voxell.GPUVectorGraphics
           {
             int idx = c - removeCount;
             Circumcenter circumcenter = na_circumcenters[idx];
-            circumcenter.sqradius += 0.001f;
             if (circumcenter.ContainsPoint(point))
             {
               int t0, t1, t2;

--- a/Runtime/CDT/CDT.Triangulate.cs
+++ b/Runtime/CDT/CDT.Triangulate.cs
@@ -57,6 +57,7 @@ namespace Voxell.GPUVectorGraphics
           {
             int idx = c - removeCount;
             Circumcenter circumcenter = na_circumcenters[idx];
+            circumcenter.sqradius += 0.001f;
             if (circumcenter.ContainsPoint(point))
             {
               int t0, t1, t2;

--- a/Runtime/CDT/CDT.TriangulationUtil.cs
+++ b/Runtime/CDT/CDT.TriangulationUtil.cs
@@ -5,35 +5,38 @@ namespace Voxell.GPUVectorGraphics
 {
   public partial class CDT
   {
-    /// <summary>Create rect-triangles using the last 4 elements of the point array.</summary>
-    private static void CreateRectTriangle(
+    /// <summary>Create super-triangle using the last 3 elements of the point array.</summary>
+    private static void CreateSuperTriangle(
       in float2 minRect, in float2 maxRect,
       ref NativeArray<float2> na_points,
       ref NativeList<int> na_triangles,
-      ref NativeList<Circumcenter> na_circumcenters
+      ref NativeList<Cirumcircle> na_cirumcircles
     )
     {
       int pointCount = na_points.Length;
-      float2 marginedMinRect = minRect - MARGIN;
-      float2 marginedMaxRect = maxRect + MARGIN;
-      int r0 = pointCount-4;
-      int r1 = pointCount-3;
-      int r2 = pointCount-2;
-      int r3 = pointCount-1;
+      float width = maxRect.x - minRect.x;
+      float height = maxRect.y - minRect.y;
+      float marginedWidth = width + MARGIN;
+      float marginedHeight = height + MARGIN;
 
-      na_points[r0] = marginedMinRect;
-      na_points[r1] = new float2(marginedMinRect.x, marginedMaxRect.y);
-      na_points[r2] = marginedMaxRect;
-      na_points[r3] = new float2(marginedMaxRect.x, marginedMinRect.y);
+      int r0 = pointCount-3;
+      int r1 = pointCount-2;
+      int r2 = pointCount-1;
 
-      AddTriAndCircum(in na_points, ref na_triangles, ref na_circumcenters, r0, r1, r2);
-      AddTriAndCircum(in na_points, ref na_triangles, ref na_circumcenters, r0, r2, r3);
+      // left bottom
+      na_points[r0] = new float2(minRect.x - marginedWidth, minRect.y - marginedHeight);
+      // right bottom
+      na_points[r1] = new float2(maxRect.x + marginedWidth, minRect.y - marginedHeight);
+      // top
+      na_points[r2] = new float2(minRect.x + width*0.5f, maxRect.y + marginedHeight);
+
+      AddTriAndCircum(in na_points, ref na_triangles, ref na_cirumcircles, r0, r1, r2);
     }
 
-    /// <summary>Remove all triangles associated with the rect-triangle.</summary>
-    private static void RemoveRectTriangle(in int pointCount, ref NativeList<int> na_triangles)
+    /// <summary>Remove all triangles associated with the super-triangle.</summary>
+    private static void RemoveSuperTriangle(in int pointCount, ref NativeList<int> na_triangles)
     {
-      for (int p=pointCount-4; p < pointCount; p++)
+      for (int p=pointCount-3; p < pointCount; p++)
       {
         int triangleCount = na_triangles.Length/3;
         int removeCount = 0;
@@ -58,7 +61,7 @@ namespace Voxell.GPUVectorGraphics
     private static void CreateTrianglesForNewPoint(
       in int pointIdx, in float2 point,
       in NativeList<Edge> na_edges, in NativeArray<float2> na_points,
-      ref NativeList<int> na_triangles, ref NativeList<Circumcenter> na_circumcenters
+      ref NativeList<int> na_triangles, ref NativeList<Cirumcircle> na_cirumcircles
     )
     {
       int edgeCount = na_edges.Length;
@@ -70,9 +73,9 @@ namespace Voxell.GPUVectorGraphics
         float2 p1 = na_points[edge.e1];
 
         if (VGMath.IsClockwise(in point, in p0, in p1))
-          AddTriAndCircum(in na_points, ref na_triangles, ref na_circumcenters, pointIdx, edge.e0, edge.e1);
+          AddTriAndCircum(in na_points, ref na_triangles, ref na_cirumcircles, pointIdx, edge.e0, edge.e1);
         else
-          AddTriAndCircum(in na_points, ref na_triangles, ref na_circumcenters, pointIdx, edge.e1, edge.e0);
+          AddTriAndCircum(in na_points, ref na_triangles, ref na_cirumcircles, pointIdx, edge.e1, edge.e0);
       }
     }
 

--- a/Runtime/CDT/CDT.Util.cs
+++ b/Runtime/CDT/CDT.Util.cs
@@ -36,7 +36,7 @@ namespace Voxell.GPUVectorGraphics
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void AddTriAndCircum(
       in NativeArray<float2> na_points, ref NativeList<int> na_triangles,
-      ref NativeList<Circumcenter> na_circumcenters,
+      ref NativeList<Cirumcircle> na_cirumcircles,
       int t0, int t1, int t2
     )
     {
@@ -44,16 +44,16 @@ namespace Voxell.GPUVectorGraphics
       float2 p0 = na_points[t0];
       float2 p1 = na_points[t1];
       float2 p2 = na_points[t2];
-      na_circumcenters.Add(new Circumcenter(p0, p1, p2));
+      na_cirumcircles.Add(new Cirumcircle(p0, p1, p2));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void RemoveTriAndCircum(
-      ref NativeList<Circumcenter> na_circumcenters, ref NativeList<int> na_triangles, int idx
+      ref NativeList<Cirumcircle> na_cirumcircles, ref NativeList<int> na_triangles, int idx
     )
     {
       RemoveTriangle(ref na_triangles, idx);
-      na_circumcenters.RemoveAt(idx);
+      na_cirumcircles.RemoveAt(idx);
     }
   }
 }

--- a/Runtime/CDT/CDT.cs
+++ b/Runtime/CDT/CDT.cs
@@ -6,7 +6,7 @@ namespace Voxell.GPUVectorGraphics
 {
   public static partial class CDT
   {
-    private const float MARGIN = 10.0f;
+    private const float MARGIN = 1.0f;
 
     /// <summary>Constraint delaunay triangulation based on a contour.</summary>
     /// <param name="minRect">minimum point of the point set</param>
@@ -41,8 +41,8 @@ namespace Voxell.GPUVectorGraphics
       out NativeArray<float2> na_points, out NativeList<int> na_triangles
     )
     {
-      // last 4 points are for the rect-triangle (will be used throughout the CDT process too)
-      na_points = new NativeArray<float2>(points.Length + 4, Allocator.TempJob);
+      // last 3 points are for the super-triangle (will be used throughout the CDT process too)
+      na_points = new NativeArray<float2>(points.Length + 3, Allocator.TempJob);
       na_triangles = new NativeList<int>(Allocator.TempJob);
 
       NativeSlice<float2> na_points_slice = na_points.Slice(0, points.Length);

--- a/Runtime/Font/FontCurve.cs
+++ b/Runtime/Font/FontCurve.cs
@@ -8,9 +8,11 @@ namespace Voxell.GPUVectorGraphics.Font
 {
   public class FontCurve : ScriptableObject
   {
-    // public const float ENLARGE = 1.0f;
-    // public const float INV_ENLARGE = 1/ENLARGE;
+    public const float ENLARGE = 10.0f;
+    public const float INV_ENLARGE = 1/ENLARGE;
     public Glyph[] Glyphs => _glyphs;
+    public int[] CharCodes => _charCodes;
+    public int[] GlyphIndices => _glyphIndices;
 
     /// <summary>Bezier contour for each character.</summary>
     [SerializeField, NonReorderable] private Glyph[] _glyphs;
@@ -85,7 +87,7 @@ namespace Voxell.GPUVectorGraphics.Font
 
         for (int s=0; s < segmentCount; s++)
         {
-          pointList.Add(glyphContour.segments[s].p0);
+          pointList.Add(glyphContour.segments[s].p0 * ENLARGE);
           contourList.Add(new CDT.ContourPoint(contourStart+s, c));
         }
         contourList.Add(new CDT.ContourPoint(contourStart, c));
@@ -101,7 +103,7 @@ namespace Voxell.GPUVectorGraphics.Font
       Vector3[] vertices = new Vector3[points.Length];
       for (int p=0; p < points.Length; p++)
       {
-        float2 point = points[p];
+        float2 point = points[p] * INV_ENLARGE;
         vertices[p] = new Vector3(point.x, point.y, 0.0f);
       }
 

--- a/Runtime/Font/FontCurve.cs
+++ b/Runtime/Font/FontCurve.cs
@@ -1,30 +1,111 @@
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 using UnityEngine;
+using Unity.Mathematics;
+using Unity.Collections;
 
 namespace Voxell.GPUVectorGraphics.Font
 {
   public class FontCurve : ScriptableObject
   {
+    // public const float ENLARGE = 1.0f;
+    // public const float INV_ENLARGE = 1/ENLARGE;
     public Glyph[] Glyphs => _glyphs;
 
     /// <summary>Bezier contour for each character.</summary>
     [SerializeField, NonReorderable] private Glyph[] _glyphs;
 
-    /// <summary>Mapping index for each characters.</summary>
-    [SerializeField, NonReorderable] private int[] _charMap;
+    /// <summary>Character codes.</summary>
+    [SerializeField, NonReorderable] private int[] _charCodes;
+    /// <summary>Glyph index of the corresponding character.</summary>
+    [SerializeField, NonReorderable] private int[] _glyphIndices;
 
-    public void Initialize(Glyph[] glyphs, int[] charMap)
+    public void Initialize(Glyph[] glyphs, int[] charCodes, int[] glyphIndices)
     {
       _glyphs = glyphs;
-      _charMap = charMap;
+      _charCodes = charCodes;
+      _glyphIndices = glyphIndices;
     }
 
-    /// <summary>Try obtaining the glyph index of a certain character.</summary>
-    /// <returns>-1 if character does not exsists, else index of the character's glyph.</returns>
-    public int TryGetGlyhIndex(char character)
+    /// <summary>Search for the glyph index of a certain character through binary search.</summary>
+    /// <returns>0 if character does not exsists, else index of the character's glyph.</returns>
+    public int SearchGlyhIndex(char character)
     {
-      int index = -1;
-      if (character < _charMap.Length) index = _charMap[character];
-      return index;
+      int __len = _charCodes.Length;
+      int __first = 0;
+      int __half;
+      int __middle;
+
+      // binary search
+      while (__len > 0)
+      {
+        __half = __len >> 1;
+        __middle = __first + __half;
+
+        int midCode = _charCodes[__middle];
+        if (character == midCode) return _glyphIndices[__middle];
+
+        // search first half if it is lower than the mid point
+        if (character < midCode)
+          __len = __half;
+        // search second half if it is higher than the mid point
+        else
+        {
+          __first = __middle + 1;
+          __len = __len - __half - 1;
+        }
+      }
+
+      // index of "square" glyph (a glyph repersenting that the character is not supported)
+      return 0;
+    }
+
+    /// <summary>Get character glyph through binary search.</summary>
+    /// <returns>
+    /// First glyph if character is not supported,
+    /// else the glyph representing the shape of the character
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Glyph GetCharacterGlyph(char character) => _glyphs[SearchGlyhIndex(character)];
+
+    /// <summary>Convert glyphs into points and contours.</summary>
+    public static void ExtractGlyphData(
+      in Glyph glyph, out float2[] points, out CDT.ContourPoint[] contours
+    )
+    {
+      int contourCount = glyph.contours.Length;
+      List<float2> pointList = new List<float2>();
+      List<CDT.ContourPoint> contourList = new List<CDT.ContourPoint>();
+
+      int contourStart = 0;
+      for (int c=0; c < contourCount; c++)
+      {
+        QuadraticContour glyphContour = glyph.contours[c];
+        int segmentCount = glyphContour.segments.Length;
+
+        for (int s=0; s < segmentCount; s++)
+        {
+          pointList.Add(glyphContour.segments[s].p0);
+          contourList.Add(new CDT.ContourPoint(contourStart+s, c));
+        }
+        contourList.Add(new CDT.ContourPoint(contourStart, c));
+        contourStart += segmentCount;
+      }
+
+      points = pointList.ToArray();
+      contours = contourList.ToArray();
+    }
+
+    public static Vector3[] PointsToVertices(in NativeArray<float2> points)
+    {
+      Vector3[] vertices = new Vector3[points.Length];
+      for (int p=0; p < points.Length; p++)
+      {
+        float2 point = points[p];
+        vertices[p] = new Vector3(point.x, point.y, 0.0f);
+      }
+
+      return vertices;
     }
   }
 }

--- a/Runtime/Font/FontCurve.cs
+++ b/Runtime/Font/FontCurve.cs
@@ -8,8 +8,6 @@ namespace Voxell.GPUVectorGraphics.Font
 {
   public class FontCurve : ScriptableObject
   {
-    public const float ENLARGE = 100.0f;
-    public const float INV_ENLARGE = 1/ENLARGE;
     public Glyph[] Glyphs => _glyphs;
     public int[] CharCodes => _charCodes;
     public int[] GlyphIndices => _glyphIndices;
@@ -17,16 +15,19 @@ namespace Voxell.GPUVectorGraphics.Font
     /// <summary>Bezier contour for each character.</summary>
     [SerializeField, NonReorderable] private Glyph[] _glyphs;
 
-    /// <summary>Character codes.</summary>
+    /// <summary>Supported character codes.</summary>
     [SerializeField, NonReorderable] private int[] _charCodes;
-    /// <summary>Glyph index of the corresponding character.</summary>
+    /// <summary>Glyph indices of the corresponding character codes.</summary>
     [SerializeField, NonReorderable] private int[] _glyphIndices;
+    /// <summary>Meshes of the corresponding character glyph indices.</summary>
+    [SerializeField, NonReorderable] private Mesh[] _meshes;
 
-    public void Initialize(Glyph[] glyphs, int[] charCodes, int[] glyphIndices)
+    public void Initialize(Glyph[] glyphs, int[] charCodes, int[] glyphIndices, Mesh[] meshes)
     {
       _glyphs = glyphs;
       _charCodes = charCodes;
       _glyphIndices = glyphIndices;
+      _meshes = meshes;
     }
 
     /// <summary>Search for the glyph index of a certain character through binary search.</summary>
@@ -70,6 +71,14 @@ namespace Voxell.GPUVectorGraphics.Font
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Glyph GetCharacterGlyph(char character) => _glyphs[SearchGlyhIndex(character)];
 
+    /// <summary>Get character mesh through binary search.</summary>
+    /// <returns>
+    /// First mesh if character is not supported,
+    /// else the mesh representing the shape of the character
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Mesh GetCharacterMesh(char character) => _meshes[SearchGlyhIndex(character)];
+
     /// <summary>Convert glyphs into points and contours.</summary>
     public static void ExtractGlyphData(
       in Glyph glyph, out float2[] points, out CDT.ContourPoint[] contours
@@ -87,7 +96,7 @@ namespace Voxell.GPUVectorGraphics.Font
 
         for (int s=0; s < segmentCount; s++)
         {
-          pointList.Add(glyphContour.segments[s].p0 * ENLARGE);
+          pointList.Add(glyphContour.segments[s].p0);
           contourList.Add(new CDT.ContourPoint(contourStart+s, c));
         }
         contourList.Add(new CDT.ContourPoint(contourStart, c));
@@ -103,7 +112,7 @@ namespace Voxell.GPUVectorGraphics.Font
       Vector3[] vertices = new Vector3[points.Length];
       for (int p=0; p < points.Length; p++)
       {
-        float2 point = points[p] * INV_ENLARGE;
+        float2 point = points[p];
         vertices[p] = new Vector3(point.x, point.y, 0.0f);
       }
 

--- a/Runtime/Font/FontCurve.cs
+++ b/Runtime/Font/FontCurve.cs
@@ -8,7 +8,7 @@ namespace Voxell.GPUVectorGraphics.Font
 {
   public class FontCurve : ScriptableObject
   {
-    public const float ENLARGE = 10.0f;
+    public const float ENLARGE = 100.0f;
     public const float INV_ENLARGE = 1/ENLARGE;
     public Glyph[] Glyphs => _glyphs;
     public int[] CharCodes => _charCodes;

--- a/Runtime/VGMath.cs
+++ b/Runtime/VGMath.cs
@@ -30,7 +30,7 @@ namespace Voxell.GPUVectorGraphics
       float u = (dot11 * dot02 - dot01 * dot12) * inverseDenominator;
       float v = (dot00 * dot12 - dot01 * dot02) * inverseDenominator;
 
-      return (u > 0.0f) && (v > 0.0f) && (u + v < 1.0f);
+      return (u >= 0.0f) && (v >= 0.0f) && (u + v <= 1.0f);
     }
 
     internal static bool LinesIntersect(float2 p1, float2 q1, float2 p2, float2 q2)

--- a/Runtime/VGMath.cs
+++ b/Runtime/VGMath.cs
@@ -6,32 +6,27 @@ namespace Voxell.GPUVectorGraphics
   internal static class VGMath
   {
     /// <summary>Determines if a point is inside a triangle.</summary>
-    internal static bool PointInTriangle(
-      float2 point, float2 a, float2 b, float2 c
-    )
+    /// <remarks>
+    /// https://stackoverflow.com/questions/2049582/how-to-determine-if-a-point-is-in-a-2d-triangle
+    /// </remarks>
+    internal static bool PointInTriangle(float2 p, float2 p0, float2 p1, float2 p2)
     {
-      float2 p0 = c - a;
-      float2 p1 = b - a;
-      float2 p2 = point - a;
+      float d1, d2, d3;
+      bool hasNeg, hasPos;
 
-      float dot00 = math.dot(p0, p0);
-      float dot01 = math.dot(p0, p1);
-      float dot02 = math.dot(p0, p2);
-      float dot11 = math.dot(p1, p1);
-      float dot12 = math.dot(p1, p2);
-      float denominator = dot00 * dot11 - dot01 * dot01;
+      d1 = VertEdgeSign(p, p0, p1);
+      d2 = VertEdgeSign(p, p1, p2);
+      d3 = VertEdgeSign(p, p2, p0);
 
-      // triangle has zero-area
-      // treat query point as not being inside
-      if (denominator == 0.0f) return false;
+      hasNeg = (d1 < 0) || (d2 < 0) || (d3 < 0);
+      hasPos = (d1 > 0) || (d2 > 0) || (d3 > 0);
 
-      // compute
-      float inverseDenominator = 1.0f / denominator;
-      float u = (dot11 * dot02 - dot01 * dot12) * inverseDenominator;
-      float v = (dot00 * dot12 - dot01 * dot02) * inverseDenominator;
-
-      return (u >= 0.0f) && (v >= 0.0f) && (u + v <= 1.0f);
+      return !(hasNeg && hasPos);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static float VertEdgeSign(float2 p, float2 p0, float2 p1)
+      => (p.x - p1.x) * (p0.y - p1.y) - (p0.x - p1.x) * (p.y - p1.y);
 
     internal static bool LinesIntersect(float2 p1, float2 q1, float2 p2, float2 q2)
     {

--- a/Runtime/VGMath.cs
+++ b/Runtime/VGMath.cs
@@ -18,8 +18,8 @@ namespace Voxell.GPUVectorGraphics
       d2 = VertEdgeSign(p, p1, p2);
       d3 = VertEdgeSign(p, p2, p0);
 
-      hasNeg = (d1 < 0) || (d2 < 0) || (d3 < 0);
-      hasPos = (d1 > 0) || (d2 > 0) || (d3 > 0);
+      hasNeg = (d1 < 0.0f) || (d2 < 0.0f) || (d3 < 0.0f);
+      hasPos = (d1 > 0.0f) || (d2 > 0.0f) || (d3 > 0.0f);
 
       return !(hasNeg && hasPos);
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache 2.0",
   "unity": "2020.4",
   "unityRelease": "0f1",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "dependencies": {
     "com.unity.mathematics": "1.2.5",
     "com.unity.collections": "1.2.3",


### PR DESCRIPTION
## [0.3.3]

### New Features

- `FontCurve` stores an array of precomputed meshes on import.
- Implementation of binary search to search for character's glyph/mesh index.

### Changes

- Burst Compile uses high precision float and strict float mode.
- Reduced `MARGIN` from 10.0f to 1.0f.
- Renamed `Circumcenter` to `Circumcircle`.
- Renamed `GenerateMeshDataFromGlyph` to `ExtractGlyphData`.
- Increased `FontImporter` verion from 2 to 3.
- Instead of `charMaps`, `FontCurve` now stores 2 separate arrays:
  - `charCodes`: an array of supported characters.
  - `glyphIndices`: an array of glyph indices corresponding to the supported character codes.
- Uses "super-triangle" instead of "rect-triangles" as there is an elegant way to create a huge triangle that encapsulates all points inside.
  1. Calculate bounding-box (min/max rect) of the points.
  2. Place the bounding-box on a line.
   ```
    __
   |__|
   ----
   ```
  3. Place 2 more of the same box at the top and bottom of the current box.
   ```
    __
   |__|
    __
   |__|
    __
   |__|
   ----
   ```
  4. Place another 2 more of the same box at the left and right of the bottom most box.
   ```
         __
        |__|
         __
        |__|
    __   __   __
   |__| |__| |__|
   --------------
   ```
  5. Now, connect the "left-bottom most" point, "right-bottom most" point, and the "middle-top-most" point together.
   ```
         __                 /\      
        |__|               /__\     
         __               / __ \    
        |__|             / |__| \   
    __   __   __       _/   __   \_ 
   |__| |__| |__|     |/_| |__| |_\|
   ----------------------------------
   ```
  6. And now you get a "super-triangle" that encapsulates all the points in the middle box! (of course, you can add some kind of margin to the box itself to enlarge the "super-triangle" just to make sure!)

### Bug Fixes

- `PointInTriangle` method in `VGMath` is much more accurate (to handle edge cases) and computationally cheap.
- Removed addition of `EPSILON` to `div` in `Cirumcircle` to prevent numerical inaccuracy.
- `TriEdgeIntersect` method now checks for similarity based on point position rather than index as there might be duplicated points that have a different index.